### PR TITLE
Feat/new cop no post in graph ql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 
 # rspec failure tracking
 .rspec_status
+.DS_STORE

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-mable (0.1.3)
+    rubocop-mable (0.1.4)
       rubocop
 
 GEM
@@ -56,6 +56,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
 
 DEPENDENCIES
   pry

--- a/README.md
+++ b/README.md
@@ -4,21 +4,32 @@ Mable's custom Rubocop cops
 
 ## Cops
 
-```
+`
+Mable/NoPostInGraphQL:
+Description: 'Replace post in graphql specs with method'
+Enabled: true
+VersionAdded: '0.1.4'
+ReplacePostWith: 'make_graphql_request'
+AllowedGraphQLPaths:
+
+- "/graphql"
+- "graphql_path"
+
 Mable/NoSafetyAssured:
-  Description: 'An extra check to ensure that the safety_assured is required'
-  Enabled: true
-  VersionAdded: '0.1.3'
+Description: 'An extra check to ensure that the safety_assured is required'
+Enabled: true
+VersionAdded: '0.1.3'
 
 Mable/GraphQLHelperSpecs:
-  Description: 'Avoid hardcoding GraphQl path use helper instead.'
-  Enabled: true
-  VersionAdded: '0.1.2'
+Description: 'Avoid hardcoding GraphQl path use helper instead.'
+Enabled: true
+VersionAdded: '0.1.2'
 
 Mable/HardcodedDatabaseFactoryBotId:
-  Enabled: true
-  Description: 'Avoid hardcoding factory bot database IDs, instead, dynamically test for the ID'
-  VersionAdded: '0.1.1'
+Enabled: true
+Description: 'Avoid hardcoding factory bot database IDs, instead, dynamically test for the ID'
+VersionAdded: '0.1.1'
+
 ```
 
 ## Installation
@@ -48,3 +59,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 ## Code of Conduct
 
 Everyone interacting in the Rubocop::Mable project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/rubocop-mable/blob/master/CODE_OF_CONDUCT.md).
+```

--- a/config/default.yml
+++ b/config/default.yml
@@ -8,12 +8,17 @@ Mable/HardcodedDatabaseFactoryBotId:
   Description: "Avoid hardcoding factory bot database IDs, instead, dynamically test for the ID"
   VersionAdded: "0.1.1"
 
-Mable/NoPostInGraphQL:
-  Description: "Use graphQL helper method instead of use rails/rack request stack"
-  Enabled: true
-  VersionAdded: "0.1.4"
-
 Mable/NoSafetyAssured:
   Description: "An extra check to ensure that the safety_assured is required"
   Enabled: true
   VersionAdded: "0.1.3"
+
+Mable/NoPostInGraphQL:
+  Description: "Use graphQL helper method instead of use rails/rack request stack"
+  Enabled: true
+  VersionAdded: "0.1.4"
+  ReplacePostWith: "make_graphql_request"
+  SafeAutoCorrect: false
+  AllowedGraphQLPaths:
+    - "/graphql"
+    - "graphql_path"

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,14 +1,19 @@
 Mable/GraphQLHelperSpecs:
-  Description: 'Avoid hardcoding GraphQl path use helper instead.'
+  Description: "Avoid hardcoding GraphQl path use helper instead."
   Enabled: true
-  VersionAdded: '0.1.2'
+  VersionAdded: "0.1.2"
 
 Mable/HardcodedDatabaseFactoryBotId:
   Enabled: true
-  Description: 'Avoid hardcoding factory bot database IDs, instead, dynamically test for the ID'
-  VersionAdded: '0.1.1'
+  Description: "Avoid hardcoding factory bot database IDs, instead, dynamically test for the ID"
+  VersionAdded: "0.1.1"
+
+Mable/NoPostInGraphQL:
+  Description: "Use graphQL helper method instead of use rails/rack request stack"
+  Enabled: true
+  VersionAdded: "0.1.4"
 
 Mable/NoSafetyAssured:
-  Description: 'An extra check to ensure that the safety_assured is required'
+  Description: "An extra check to ensure that the safety_assured is required"
   Enabled: true
-  VersionAdded: '0.1.3'
+  VersionAdded: "0.1.3"

--- a/lib/rubocop/cop/mable/no_post_in_graph_ql.rb
+++ b/lib/rubocop/cop/mable/no_post_in_graph_ql.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Mable
+      # Enforces using a direct helper method over `post` for executing GraphQL queries,
+      # incorporating user authentication context when applicable.
+      #
+      # @safety
+      #   The cop is unsafe as user might not exist or not be called user.
+      #
+      # @example
+      #
+      #   # bad
+      #   post graphql_path, params: { query: my_query, variables: my_variables }, as: :json
+      #
+      #   # good
+      #   execute_graphql(query: my_query, variables: my_variables, user: current_user)
+      #
+      class NoPostInGraphQL < Base
+        extend AutoCorrector
+
+        MSG = 'Use `make_graphql_request` directly instead of `post` for GraphQL requests, incorporating user context.'
+
+        RESTRICT_ON_SEND = %i[post].freeze
+
+        def_node_matcher :post_graphql?, <<~PATTERN
+          (send nil? :post
+            (str _)
+            (hash
+              (pair
+                (sym :params)
+                (hash
+                  (pair (sym :query) _)
+                  (pair (sym :variables) _)
+                )
+              )
+              (pair
+                (sym :as)
+                (sym :json)
+              )
+            )
+          )
+        PATTERN
+
+        def_node_search :rspec_block?, <<~PATTERN
+          (block (send (const nil? :RSpec) {:describe :context :it} ...) ...)
+        PATTERN
+
+        def on_send(node)
+          return unless within_rspec_block?(node)
+
+          # Check if the method is `post` and it includes `params:`
+          params_pair = node.arguments.find do |arg|
+            arg.hash_type? && arg.pairs.any? { |pair| pair.key.sym_type? && pair.key.value == :params }
+          end
+
+          return unless params_pair
+
+          # Access pairs directly from params_pair
+          params_hash = params_pair.pairs.find { |pair| pair.key.value == :params }.value
+
+          return unless params_hash.hash_type?
+
+          query_pair = params_hash.pairs.find { |p| p.key.value == :query }
+          variables_pair = params_hash.pairs.find { |p| p.key.value == :variables }
+
+          query = query_pair&.value&.source
+          variables = variables_pair&.value&.source
+
+          replacement = cop_config['ReplacePostWith'] || 'make_graphql_request'
+          execute_call = "#{replacement}(query: #{query}"
+          execute_call += ', user: user'
+          execute_call += ", variables: #{variables}" if variables
+          execute_call += ')'
+
+          add_offense(node) do |corrector|
+            corrector.replace(node.loc.expression, execute_call)
+          end
+        end
+
+        private
+
+        def within_rspec_block?(node)
+          node.each_ancestor.any? { |ancestor| rspec_block?(ancestor) }
+        end
+
+        def find_login_as_user(node)
+          # Find the topmost describe/context block
+          rspec_root = node.each_ancestor.find { |ancestor| rspec_block?(ancestor) }
+          return unless rspec_root
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/mable_cops.rb
+++ b/lib/rubocop/cop/mable_cops.rb
@@ -2,4 +2,5 @@
 
 require_relative 'mable/graph_ql_helper_specs'
 require_relative 'mable/hardcoded_database_factory_bot_id'
+require_relative 'mable/no_post_in_graph_ql'
 require_relative 'mable/no_safety_assured'

--- a/lib/rubocop/mable/version.rb
+++ b/lib/rubocop/mable/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Mable
-    VERSION = '0.1.3'
+    VERSION = '0.1.4'
   end
 end

--- a/spec/rubocop/cop/mable/graph_ql_helper_specs_spec.rb
+++ b/spec/rubocop/cop/mable/graph_ql_helper_specs_spec.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
-#
+
 RSpec.describe RuboCop::Cop::Mable::GraphQLHelperSpecs, :config do
   let(:config) { RuboCop::Config.new }
+  let(:spacer_start) { 0 }
+  let(:spacer_end) { 0 }
+
   let(:offense_msg) do
     'Avoid hardcoding GraphQL URL paths, instead, use the helper method.'
   end
@@ -22,16 +25,15 @@ RSpec.describe RuboCop::Cop::Mable::GraphQLHelperSpecs, :config do
 
   context 'when using url path helper' do
     context 'with params' do
-      let(:code) { "post graphql_path, params: { query: graphql_query }" }
+      let(:code) { 'post graphql_path, params: { query: graphql_query }' }
 
       it_behaves_like 'code that does not register an offense'
     end
 
     context 'without params' do
-      let(:code) { "post graphql_path" }
+      let(:code) { 'post graphql_path' }
 
       it_behaves_like 'code that does not register an offense'
     end
   end
 end
-

--- a/spec/rubocop/cop/mable/graph_ql_helper_specs_spec.rb
+++ b/spec/rubocop/cop/mable/graph_ql_helper_specs_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Mable::GraphQLHelperSpecs, :config do
-  let(:config) { RuboCop::Config.new }
+  let(:config) { RuboCop::ConfigLoader.default_configuration }
   let(:spacer_start) { 0 }
   let(:spacer_end) { 0 }
 

--- a/spec/rubocop/cop/mable/hardcoded_database_factory_bot_id_spec.rb
+++ b/spec/rubocop/cop/mable/hardcoded_database_factory_bot_id_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe RuboCop::Cop::Mable::HardcodedDatabaseFactoryBotId, :config do
-  let(:config) { RuboCop::Config.new }
+  let(:config) { RuboCop::ConfigLoader.default_configuration }
   let(:spacer_start) { 0 }
   let(:spacer_end) { 0 }
 

--- a/spec/rubocop/cop/mable/hardcoded_database_factory_bot_id_spec.rb
+++ b/spec/rubocop/cop/mable/hardcoded_database_factory_bot_id_spec.rb
@@ -4,6 +4,8 @@ require 'spec_helper'
 
 RSpec.describe RuboCop::Cop::Mable::HardcodedDatabaseFactoryBotId, :config do
   let(:config) { RuboCop::Config.new }
+  let(:spacer_start) { 0 }
+  let(:spacer_end) { 0 }
 
   context 'when registering an offense' do
     let(:offense_msg) do

--- a/spec/rubocop/cop/mable/no_post_in_graph_ql_spec.rb
+++ b/spec/rubocop/cop/mable/no_post_in_graph_ql_spec.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Mable::NoPostInGraphQL, :config do
-  subject(:cop) { described_class.new(config) }
-
-  let(:config) { RuboCop::Config.new }
+  let(:config) { RuboCop::ConfigLoader.default_configuration }
   let(:spacer_start) { 0 }
   let(:spacer_end) { 0 }
 
   let(:offense_msg) do
-    'Use `make_graphql_request` directly instead of `post` for GraphQL requests, incorporating user context.'
+    "Use 'ReplacePostWith' default: `make_graphql_request` directly instead of `post` for GraphQL requests, incorporating user context."
   end
 
   context 'when using post in GraphQL specs' do
@@ -47,7 +45,7 @@ RSpec.describe RuboCop::Cop::Mable::NoPostInGraphQL, :config do
     end
   end
 
-  context 'when using helper method (make_graphql_request' do
+  context 'when using helper method (make_graphql_request)' do
     context 'within RSpec blocks' do
       context 'with query and variables' do
         let(:code) do

--- a/spec/rubocop/cop/mable/no_post_in_graph_ql_spec.rb
+++ b/spec/rubocop/cop/mable/no_post_in_graph_ql_spec.rb
@@ -10,8 +10,16 @@ RSpec.describe RuboCop::Cop::Mable::NoPostInGraphQL, :config do
   end
 
   context 'when using post in GraphQL specs' do
-    context 'without query' do
+    context 'with query and path as string' do
       let(:code) { "RSpec.describe 'GraphQL' do post '/graphql', params: { query: graphql_query } end" }
+      let(:spacer_start) { "RSpec.describe 'GraphQL' do ".length }
+      let(:spacer_end) { ' end'.length }
+
+      it_behaves_like 'code that registers an offense'
+    end
+
+    context 'with query and path as helper' do
+      let(:code) { "RSpec.describe 'GraphQL' do post graphql_path, params: { query: graphql_query } end" }
       let(:spacer_start) { "RSpec.describe 'GraphQL' do ".length }
       let(:spacer_end) { ' end'.length }
 

--- a/spec/rubocop/cop/mable/no_post_in_graph_ql_spec.rb
+++ b/spec/rubocop/cop/mable/no_post_in_graph_ql_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Mable::NoPostInGraphQL, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
+  let(:spacer_start) { 0 }
+  let(:spacer_end) { 0 }
+
+  let(:offense_msg) do
+    'Use `make_graphql_request` directly instead of `post` for GraphQL requests, incorporating user context.'
+  end
+
+  context 'when using post in GraphQL specs' do
+    context 'without query' do
+      let(:code) { "RSpec.describe 'GraphQL' do post '/graphql', params: { query: graphql_query } end" }
+      let(:spacer_start) { "RSpec.describe 'GraphQL' do ".length }
+      let(:spacer_end) { ' end'.length }
+
+      it_behaves_like 'code that registers an offense'
+    end
+
+    context 'when not using params' do
+      let(:code) { "RSpec.describe 'GraphQL' do post graphql_path end" }
+
+      it_behaves_like 'code that does not register an offense'
+    end
+
+    context 'when not using params without hash value' do
+      let(:code) { "RSpec.describe 'GraphQL' do post graphql_path, params: the_params end" }
+
+      it_behaves_like 'code that does not register an offense'
+    end
+  end
+
+  context 'outside RSpec blocks' do
+    context 'with query' do
+      let(:code) { "post '/graphql', params: { query: graphql_query }" }
+
+      it_behaves_like 'code that does not register an offense'
+    end
+
+    context 'without query' do
+      let(:code) { "post '/graphql'" }
+
+      it_behaves_like 'code that does not register an offense'
+    end
+  end
+
+  context 'when using helper method (make_graphql_request' do
+    context 'within RSpec blocks' do
+      context 'with query and variables' do
+        let(:code) do
+          "RSpec.describe 'GraphQL' do make_graphql_request(query: graphql_query, variables: graphql_variables) end"
+        end
+
+        it_behaves_like 'code that does not register an offense'
+      end
+
+      context 'without query' do
+        let(:code) { "RSpec.describe 'GraphQL' do make_graphql_request end" }
+
+        it_behaves_like 'code that does not register an offense'
+      end
+    end
+
+    context 'outside RSpec blocks' do
+      context 'with query and variables' do
+        let(:code) { 'make_graphql_request(query: graphql_query, variables: graphql_variables)' }
+
+        it_behaves_like 'code that does not register an offense'
+      end
+
+      context 'without query' do
+        let(:code) { 'make_graphql_request' }
+
+        it_behaves_like 'code that does not register an offense'
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/mable/no_safety_assured_spec.rb
+++ b/spec/rubocop/cop/mable/no_safety_assured_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Mable::NoSafetyAssured, :config do
-  let(:config) { RuboCop::Config.new }
+  let(:config) { RuboCop::ConfigLoader.default_configuration }
   let(:spacer_start) { 0 }
   let(:spacer_end) { 0 }
 

--- a/spec/rubocop/cop/mable/no_safety_assured_spec.rb
+++ b/spec/rubocop/cop/mable/no_safety_assured_spec.rb
@@ -2,6 +2,8 @@
 
 RSpec.describe RuboCop::Cop::Mable::NoSafetyAssured, :config do
   let(:config) { RuboCop::Config.new }
+  let(:spacer_start) { 0 }
+  let(:spacer_end) { 0 }
 
   context 'when registering an offense' do
     let(:offense_msg) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 require 'rubocop-mable'
 require 'rubocop/rspec/support'
 require 'pry'
-Dir.glob(File.dirname(__dir__) + "/spec/support/**/*.rb").each { |file| require file }
+Dir.glob(File.dirname(__dir__) + '/spec/support/**/*.rb').each { |file| require file }
 
 RSpec.configure do |config|
   config.include RuboCop::RSpec::ExpectOffense

--- a/spec/support/shared_examples_for_code_offenses.rb
+++ b/spec/support/shared_examples_for_code_offenses.rb
@@ -5,7 +5,7 @@ RSpec.shared_examples 'code that registers an offense' do
     expect_offense(
       <<~RUBY
         #{code}
-        #{' ' * spacer_start}#{'^' * (code.length - spacer_start - spacer_end)} #{offense_msg}
+        #{' ' * spacer_start}#{'^' * (code.length - spacer_start - spacer_end)} #{cop.name}: #{offense_msg}
       RUBY
     )
   end

--- a/spec/support/shared_examples_for_code_offenses.rb
+++ b/spec/support/shared_examples_for_code_offenses.rb
@@ -1,12 +1,12 @@
-require "spec_helper"
+require 'spec_helper'
 
 RSpec.shared_examples 'code that registers an offense' do
   it 'registers an offense' do
     expect_offense(
-    <<~RUBY
+      <<~RUBY
         #{code}
-        #{'^' * code.length} #{offense_msg}
-    RUBY
+        #{' ' * spacer_start}#{'^' * (code.length - spacer_start - spacer_end)} #{offense_msg}
+      RUBY
     )
   end
 end
@@ -14,9 +14,9 @@ end
 RSpec.shared_examples 'code that does not register an offense' do
   it 'does not register an offense' do
     expect_no_offenses(
-    <<~RUBY
+      <<~RUBY
         #{code}
-    RUBY
+      RUBY
     )
   end
 end


### PR DESCRIPTION
```
      # Enforces using a direct helper method over `post` for executing GraphQL queries,
      # incorporating user authentication context when applicable.
      #
      # @safety
      #   The cop is unsafe as user might not exist or not be called user.
      #
      # @example
      #
      #   # bad
      #   post graphql_path, params: { query: my_query, variables: my_variables }, as: :json
      #
      #   # good
      #   execute_graphql(query: my_query, variables: my_variables, user: current_user)
```