### PR TITLE
Add support for a post-to graphql with `as: :json`

### DIFF
--- a/lib/rubocop/cop/mable/no_post_in_graph_ql.rb
+++ b/lib/rubocop/cop/mable/no_post_in_graph_ql.rb
@@ -35,6 +35,10 @@ module RuboCop
                   (pair (sym :variables) _)? # Optional :variables pair
                 )
               )
+              (pair # Optional as: :json
+                (sym :as)
+                (sym :json)
+              )?
             )
           )
         PATTERN

--- a/spec/rubocop/cop/mable/no_post_in_graph_ql_spec.rb
+++ b/spec/rubocop/cop/mable/no_post_in_graph_ql_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe RuboCop::Cop::Mable::NoPostInGraphQL, :config do
   let(:config) { RuboCop::ConfigLoader.default_configuration }
+  let(:correction) { 'make_graphql_request(query: graphql_query, user: user)' }
 
   let(:offense_msg) do
     "Use 'ReplacePostWith' default: `make_graphql_request` directly instead of `post` for GraphQL requests, incorporating user context."
@@ -17,7 +18,7 @@ RSpec.describe RuboCop::Cop::Mable::NoPostInGraphQL, :config do
 
     context 'with query and path as helper' do
       let(:code) { "RSpec.describe 'GraphQL' do #{offense_method} end" }
-      let(:offense_method) { "post graphql_path, params: { query: graphql_query }" }
+      let(:offense_method) { 'post graphql_path, params: { query: graphql_query }' }
 
       it_behaves_like 'code that registers an offense'
     end
@@ -25,6 +26,7 @@ RSpec.describe RuboCop::Cop::Mable::NoPostInGraphQL, :config do
     context 'when post includes variables' do
       let(:code) { "RSpec.describe 'GraphQL' do #{offense_method} end" }
       let(:offense_method) { "post '/graphql', params: { query: graphql_query, variables: { some: :variables } }" }
+      let(:correction) { 'make_graphql_request(query: graphql_query, user: user, variables: { some: :variables })' }
 
       it_behaves_like 'code that registers an offense'
     end

--- a/spec/rubocop/cop/mable/no_post_in_graph_ql_spec.rb
+++ b/spec/rubocop/cop/mable/no_post_in_graph_ql_spec.rb
@@ -17,7 +17,21 @@ RSpec.describe RuboCop::Cop::Mable::NoPostInGraphQL, :config do
 
     context 'with query and path as helper' do
       let(:code) { "RSpec.describe 'GraphQL' do #{offense_method} end" }
-      let(:offense_method) { "post '/graphql', params: { query: graphql_query }" }
+      let(:offense_method) { "post graphql_path, params: { query: graphql_query }" }
+
+      it_behaves_like 'code that registers an offense'
+    end
+
+    context 'when post includes variables' do
+      let(:code) { "RSpec.describe 'GraphQL' do #{offense_method} end" }
+      let(:offense_method) { "post '/graphql', params: { query: graphql_query, variables: { some: :variables } }" }
+
+      it_behaves_like 'code that registers an offense'
+    end
+
+    context 'when post includes `as: :json`' do
+      let(:code) { "RSpec.describe 'GraphQL' do #{offense_method} end" }
+      let(:offense_method) { "post '/graphql', params: { query: graphql_query }, as: :json" }
 
       it_behaves_like 'code that registers an offense'
     end
@@ -35,14 +49,14 @@ RSpec.describe RuboCop::Cop::Mable::NoPostInGraphQL, :config do
     end
   end
 
-  context 'outside RSpec blocks' do
-    context 'with query' do
+  context 'when outside RSpec blocks' do
+    describe 'with query' do
       let(:code) { "post '/graphql', params: { query: graphql_query }" }
 
       it_behaves_like 'code that does not register an offense'
     end
 
-    context 'without query' do
+    describe 'without query' do
       let(:code) { "post '/graphql'" }
 
       it_behaves_like 'code that does not register an offense'
@@ -50,8 +64,8 @@ RSpec.describe RuboCop::Cop::Mable::NoPostInGraphQL, :config do
   end
 
   context 'when using helper method (make_graphql_request)' do
-    context 'within RSpec blocks' do
-      context 'with query and variables' do
+    context 'when within RSpec blocks' do
+      describe 'with query and variables' do
         let(:code) do
           "RSpec.describe 'GraphQL' do make_graphql_request(query: graphql_query, variables: graphql_variables) end"
         end
@@ -59,21 +73,21 @@ RSpec.describe RuboCop::Cop::Mable::NoPostInGraphQL, :config do
         it_behaves_like 'code that does not register an offense'
       end
 
-      context 'without query' do
+      describe 'without query' do
         let(:code) { "RSpec.describe 'GraphQL' do make_graphql_request end" }
 
         it_behaves_like 'code that does not register an offense'
       end
     end
 
-    context 'outside RSpec blocks' do
-      context 'with query and variables' do
+    context 'when outside RSpec blocks' do
+      describe 'with query and variables' do
         let(:code) { 'make_graphql_request(query: graphql_query, variables: graphql_variables)' }
 
         it_behaves_like 'code that does not register an offense'
       end
 
-      context 'without query' do
+      describe 'without query' do
         let(:code) { 'make_graphql_request' }
 
         it_behaves_like 'code that does not register an offense'

--- a/spec/support/shared_examples_for_code_offenses.rb
+++ b/spec/support/shared_examples_for_code_offenses.rb
@@ -10,21 +10,29 @@ RSpec.shared_examples 'code that registers an offense' do
       spacer_start = code.index(offense_method)
     end
 
-    expect_offense(
-      <<~RUBY
-        #{code}
-        #{' ' * spacer_start}#{'^' * caret_length} #{cop.name}: #{offense_msg}
+    expect_offense(<<~RUBY)
+      #{code}
+      #{' ' * spacer_start}#{'^' * caret_length} #{cop.name}: #{offense_msg}
+    RUBY
+
+    if respond_to?(:correction)
+      start_index = code.index(offense_method)
+      end_index = start_index + offense_method.size
+
+      perm_start = code[0..start_index - 1]
+      perm_end = code[end_index..]
+
+      expect_correction(<<~RUBY)
+        #{perm_start}#{correction}#{perm_end}
       RUBY
-    )
+    end
   end
 end
 
 RSpec.shared_examples 'code that does not register an offense' do
   it 'does not register an offense' do
-    expect_no_offenses(
-      <<~RUBY
-        #{code}
-      RUBY
-    )
+    expect_no_offenses(<<~RUBY)
+      #{code}
+    RUBY
   end
 end


### PR DESCRIPTION
Sometimes the graphql post as `as: :json` at the end, and we don't need that.

Example:

```
 post graphql_path, params: { query: query_scheduled_event, variables: { derivedUniqueId: derived_unique_id } }, as: :json
```

Should just discard it during auto-correct and end up with:
```
 make_graphql_request(query: query_scheduled_event, user: user, variables: { derivedUniqueId: derived_unique_id })
```