### PR TITLE
Add Dependabot configuration for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Jira Ticket

Non-production code change

## Why are we making this change? Why are we doing it this way?

This adds Dependabot configuration to enable automated dependency updates and security vulnerability scanning for this repository. This is part of a broader rollout across all BetterCaring backend repositories to improve security posture and reduce technical debt.

Dependabot will:
- Automatically detect outdated dependencies and security vulnerabilities
- Create PRs weekly for gem updates and GitHub Actions workflow updates
- Limit to 5 concurrent open PRs to manage review load

This configuration includes both bundler (for Ruby gems) and github-actions (for workflow dependencies) to keep the entire repository up to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)